### PR TITLE
The Big One: integrate and extend Thao's selectedBoard logic

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,6 @@
 body {
   color: #000;
+  margin: 1rem;
 }
 
 .page__container {
@@ -17,12 +18,23 @@ h1 {
   align-items: center;
 }
 
+
 .boards__container {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   background-color: lightseagreen;
 }
 
+.new-board-form__container, .new-card-form__container {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+}
+
 footer {
   text-align: center;
+}
+
+button:hover {
+  cursor: pointer;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -8,11 +8,10 @@ import NewBoardForm from './components/NewBoardForm';
 function App() {
   const [boardsData, setBoardsData] = useState([]);
   // const [selectedBoard, setSelectedBoard] = useState();
-  // const [selectedBoardLabel, setSelectedBoardLabel] = useState("Select a board from the board list!");
-  const [cardsData, setCardsData] = useState();
+  const [cardsData, setCardsData] = useState([]);
 
   const [boardFormVisibility, setBoardFormVisibility] = useState(true);
-  const [boardComponentVisibility, setBoardComponentVisibility] = useState(false);
+  // const [boardComponentVisibility, setBoardComponentVisibility] = useState(false);
 
   const addBoard = (title, owner) => {
     axios
@@ -85,6 +84,7 @@ function App() {
           </section>
           <section id='selected-board'>
             <h2>Selected Board</h2>
+            <p>This is where we'll put the title of a selected board</p>
           </section>
           <section className='new-board-form__container'>
             <h2>Create a New Board</h2>
@@ -110,7 +110,7 @@ function App() {
           // cardsData={cardsData}
         />
       </div>
-      <footer><span>This is a filler footer!</span></footer>
+      <footer><span>Made with ❤️ by D18 Tigers Masha, Neema, Thao, and Yael</span></footer>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -66,7 +66,7 @@ function App() {
 
   const selectedBoardObj = useMemo(
     () => {
-      if (!selectBoard || !boardsData || !boardsData.length) {
+      if (!selectedBoard || !boardsData || !boardsData.length) {
         return undefined;
       }
       return boardsData.find(board => board.board_id === selectedBoard);

--- a/src/App.js
+++ b/src/App.js
@@ -66,7 +66,7 @@ function App() {
 
   const selectedBoardObj = useMemo(
     () => {
-      if (!selectedBoard || !boardsData || !boardsData.length) {
+      if (!selectedBoard || !boardsData?.length) {
         return undefined;
       }
       return boardsData.find(board => board.board_id === selectedBoard);
@@ -87,12 +87,11 @@ function App() {
         <section className='boards__container'>
           <section id='view-all-boards'>
             <h2>Boards</h2>
-            <BoardList boardsData={boardsData} onSelectBoard={selectBoard} />
+            <BoardList boardsData={boardsData} onSelectBoard={setSelectedBoard} />
           </section>
           <section id='selected-board'>
             <h2>Selected Board</h2>
-            <p>This is where we'll put the title of a selected board</p>
-            {/* {selectedBoardObj.title} */}
+            {selectedBoardObj?.title || 'Select a board'}
           </section>
           <section className='new-board-form__container'>
             <h2>Create a New Board</h2>

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import axios from 'axios';
 import './App.css';
 import Board from './components/Board';
@@ -7,7 +7,7 @@ import NewBoardForm from './components/NewBoardForm';
 
 function App() {
   const [boardsData, setBoardsData] = useState([]);
-  // const [selectedBoard, setSelectedBoard] = useState();
+  const [selectedBoard, setSelectedBoard] = useState(null);
   const [cardsData, setCardsData] = useState([]);
 
   const [boardFormVisibility, setBoardFormVisibility] = useState(true);
@@ -26,11 +26,6 @@ function App() {
       })
       .catch((error) => console.log(error.response.data));
   };
-
-  // How are we going to extract the array of cards from a selected board?
-  // SUGGESTED BOARD PROPS: board, onBoardSelect
-  // SUGGESTED NEWBOARDFORM PROPS: createNewBoard
-  // SUGGESTED NEWBOARDFORM STATE: title, owner
 
   const getAllBoards = () => {
     axios
@@ -63,14 +58,26 @@ function App() {
   //   // this function should change the visiblity of the Board component based on board selection
   // }
 
-  // const handleOnClick = () => {
-  //   setIsBoardComponentVisible(!isBoardComponentVisible);
-  // }
+  const selectBoard = useCallback((boardId) => {
+    setSelectedBoard(boardId);
+  },
+  [setSelectedBoard],
+  );
 
-  // useEffect(() => {
-  //   getAllBoards();
-  // }, []);
+  const selectedBoardObj = useMemo(
+    () => {
+      if (!selectBoard || !boardsData || !boardsData.length) {
+        return undefined;
+      }
+      return boardsData.find(board => board.board_id === selectedBoard);
+    },
+    [boardsData, selectedBoard],
+  );
 
+  useEffect(() => {
+    getAllBoards();
+  }, []);
+ 
   return (
     <div className='page__container'>
       <div className='content__container'>
@@ -80,11 +87,12 @@ function App() {
         <section className='boards__container'>
           <section id='view-all-boards'>
             <h2>Boards</h2>
-            {/* <BoardList boardsData={boardsData}/> */}
+            <BoardList boardsData={boardsData} onSelectBoard={selectBoard} />
           </section>
           <section id='selected-board'>
             <h2>Selected Board</h2>
             <p>This is where we'll put the title of a selected board</p>
+            {/* {selectedBoardObj.title} */}
           </section>
           <section className='new-board-form__container'>
             <h2>Create a New Board</h2>

--- a/src/components/BoardList.css
+++ b/src/components/BoardList.css
@@ -1,5 +1,6 @@
 .boards__list {
     border: 1px solid #000;
+    background-color: white;
     margin-right: 2rem;
     max-height: 9rem;
     min-height: 9rem;

--- a/src/components/BoardList.js
+++ b/src/components/BoardList.js
@@ -7,8 +7,8 @@ const BoardList = (props) => {
     <ol className="boards__list">
       {props.boardsData.map((board) => (
         <li
-          key={board.boardId}
-          onClick={() => props.onSelectBoard(board.boardId)}
+          key={`${board.board_id}-${board.owner}`}
+          onClick={() => props.onSelectBoard(board.board_id)}
           title={board.title}
         >
           {board.title}
@@ -21,7 +21,7 @@ const BoardList = (props) => {
 BoardList.propTypes = {
   boardsData: PropTypes.arrayOf(
     PropTypes.shape({
-      boardId: PropTypes.number.isRequired,
+      board_id: PropTypes.number.isRequired,
       title: PropTypes.string.isRequired,
       owner: PropTypes.string.isRequired,
     })

--- a/src/components/BoardList.js
+++ b/src/components/BoardList.js
@@ -14,7 +14,6 @@ const BoardList = (props) => {
           {board.title}
         </li>
       ))}
-      ;
     </ol>
   );
 };

--- a/src/components/Card.css
+++ b/src/components/Card.css
@@ -1,0 +1,9 @@
+.card-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: #fff8a5;
+    justify-content: center;
+    min-height: 200px;
+    padding: 2rem;
+  }

--- a/src/components/NewBoardForm.css
+++ b/src/components/NewBoardForm.css
@@ -1,9 +1,3 @@
-.new-board-form__container {
-    align-items: flex-start;
-    display: flex;
-    flex-direction: column;
-}
-
 .new-board-form__form {
     display: flex;
     flex-direction: column;

--- a/src/components/NewBoardForm.js
+++ b/src/components/NewBoardForm.js
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
-import PropTypes from "prop-types";
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import './NewBoardForm.css';
 
 const NewBoardForm = ({ onAddBoardCallback }) => {
   const [formFields, setFormFields] = useState({
-    title: "",
-    owner: "",
+    title: '',
+    owner: '',
   });
 
   const handleTitleChange = (event) => {
@@ -21,28 +22,28 @@ const NewBoardForm = ({ onAddBoardCallback }) => {
     onAddBoardCallback(formFields.title, formFields.owner);
 
     setFormFields({
-      title: "",
-      owner: "",
+      title: '',
+      owner: '',
     });
   };
 
   return (
-    <form className="new-board-form__form" onSubmit={handleFormSubmit}>
-      <label htmlFor="boardTitle">Title:</label>
+    <form className='new-board-form__form' onSubmit={handleFormSubmit}>
+      <label htmlFor='boardTitle'>Title:</label>
       <input
-        name="boardTitle"
+        name='boardTitle'
         value={formFields.title}
         onChange={handleTitleChange}
         required
       />
-      <label htmlFor="boardOwner">Owner:</label>
+      <label htmlFor='boardOwner'>Owner:</label>
       <input
-        name="boardOwner"
+        name='boardOwner'
         value={formFields.owner}
         onChange={handleOwnerChange}
         required
       />
-      <button type="submit">Submit</button>
+      <button type='submit'>Submit</button>
     </form>
   );
 };

--- a/src/components/NewCardForm.css
+++ b/src/components/NewCardForm.css
@@ -1,9 +1,3 @@
-.new-card-form__container {
-    align-items: flex-start;
-    display: flex;
-    flex-direction: column;
-}
-
 .new-card-form__form {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Long at last! Here be boards we can select!

This change will permit (on adjusting your env vars) clients to view all boards from a connected DB in BoardList as well as select a board and display its title in the "selected board" section in App (owner to be append shortly).

I believe we are going to run into issues with the naming conventions of our adversely cased data (see boardId versus board_id), so until we make the necessary transformations, please pass in the latter where necessary!

You'll notice that I also changed the key in BoardList so we can have more slightly unique keys/do away with an error that was pinging based on the ID usage. Not as solid as hashing, but works for this scale!